### PR TITLE
added tidy for formatting html outputs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get -y install fonts-ipafont-gothic \
   git \
   libxml2 \
   libxml2-utils \
+  tidy \
   devscripts \
   xsltproc \
   libsaxonhe-java \


### PR DESCRIPTION
As discussed in our last Stylesheets meeting, we are going to format the HTML outputs using `tidy` instead of `xmllint`. `xmllint` was changing the output files when formatting HTML5 which made the testing a bit harder.