### PR TITLE
Change locale / LANG to C.UTF-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM debian:bullseye-slim
+# Set LANG to UTF-8
+ENV LANG C.UTF-8
 # Enable contrib repo
 RUN sed -i "s#deb http://deb.debian.org/debian bullseye main#deb http://deb.debian.org/debian bullseye main contrib#g" /etc/apt/sources.list
 RUN apt-get update && apt-get -y install openjdk-17-jdk-headless \


### PR DESCRIPTION
As reported by @HelenaSabel, the current Dockerfile doesn't explicitly set the LOCALE to UTF-8, which ends up causing issues in Stylesheets/Test2 comparisons — e.g. the attribute value `"req_1Ǖ"` becomes `"req_1?"`.

Built and tested the image locally (by running the Stylesheet Test2), and all passed. 
